### PR TITLE
Reset is_detected flag when resetting targets

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -78,6 +78,8 @@ class ControlFlowGraph:
             os.unlink(self.symlinked_entrypoint)
 
     def reset_targets(self, functions_to_locate: typing.Union[typing.List[str], str] = None):
+        self._detected = False
+
         if type(functions_to_locate) == str:
             self._functions_to_locate = [functions_to_locate]
         elif functions_to_locate is None:

--- a/narrower.py
+++ b/narrower.py
@@ -1871,7 +1871,9 @@ class Narrower:
         targets += extractor.find_targets_in_osv_entry(vuln_id)
 
         if len(targets) > 0:
-          print("Looking for targets: " + targets)
+          print("Looking for targets: ")
+          for target in targets:
+            print("  " + target)
           graph.reset_targets(targets)
           graph.construct_from_file(self.target_file_path, False)
           detect_status = graph.did_detect()

--- a/narrower.py
+++ b/narrower.py
@@ -1871,6 +1871,7 @@ class Narrower:
         targets += extractor.find_targets_in_osv_entry(vuln_id)
 
         if len(targets) > 0:
+          print("Looking for targets: " + targets)
           graph.reset_targets(targets)
           graph.construct_from_file(self.target_file_path, False)
           detect_status = graph.did_detect()
@@ -1881,7 +1882,11 @@ class Narrower:
 
               contents_as_json['vulnerabilities'][vuln_idx]['analysis']['state'] = 'not_affected'
               contents_as_json['vulnerabilities'][vuln_idx]['analysis']['justification'] = 'code_not_reachable'
+          else:
+              if 'analysis' not in contents_as_json['vulnerabilities'][vuln_idx]:
+                contents_as_json['vulnerabilities'][vuln_idx]['analysis'] = {'state': None}
 
+              contents_as_json['vulnerabilities'][vuln_idx]['analysis']['state'] = 'exploitable'
       return contents_as_json
 
 


### PR DESCRIPTION
`cfg.py`'s `reset_targets` was not resetting its `is_detected` flag. This was causing issues when analyzing many vulnerabilities at once (in `--input-file` mode).

Specifically, say there were two vulns: A and B.

narrow would find targets in A and search for a vulnerable path. If found, `cfg`'s internal `is_detected` will be set to `true`.

Next, narrow would repeat the process for B. However, regardless of whether a path is possible, narrow will use the `is_detected` result marking B as exploitable incorrectly.

This PR depends on https://github.com/duo-labs/narrow/pull/8 merging first.